### PR TITLE
Fix for 90-degree rotation issue

### DIFF
--- a/FAST-LIO/src/IMU_Processing.hpp
+++ b/FAST-LIO/src/IMU_Processing.hpp
@@ -193,6 +193,10 @@ void ImuProcess::IMU_init(const MeasureGroup &meas, esekfom::esekf<state_ikfom, 
   state_ikfom init_state = kf_state.get_x();
   init_state.grav = S2(- mean_acc / mean_acc.norm() * G_m_s2);
   const auto& orientation = meas.imu.front()->orientation;
+
+  // TODO: Determine if this might actually be useful in certain cases. Livox lidar has 0 orientation, and
+  // keeping this code seems to mess things up when using /mavros/imu/data (causes strange rotations in base_link)
+  
   // 如果orientation消息可用的话,以IMU的orientaion作为初始姿态
   // if( orientation.x != 0 || orientation.y != 0 || orientation.z != 0 || orientation.w != 0 ){
   //   Eigen::Quaterniond qua(orientation.w, orientation.x, orientation.y, orientation.z);

--- a/FAST-LIO/src/IMU_Processing.hpp
+++ b/FAST-LIO/src/IMU_Processing.hpp
@@ -194,11 +194,12 @@ void ImuProcess::IMU_init(const MeasureGroup &meas, esekfom::esekf<state_ikfom, 
   init_state.grav = S2(- mean_acc / mean_acc.norm() * G_m_s2);
   const auto& orientation = meas.imu.front()->orientation;
   // 如果orientation消息可用的话,以IMU的orientaion作为初始姿态
-  if( orientation.x != 0 || orientation.y != 0 || orientation.z != 0 || orientation.w != 0 ){
-    // Eigen::Quaterniond qua(orientation.w, orientation.x, orientation.y, orientation.z);
-    Eigen::Quaterniond qua(1.0 , 0.0, 0.0, 0.0);
-    init_state.rot = qua;
-  }
+  // if( orientation.x != 0 || orientation.y != 0 || orientation.z != 0 || orientation.w != 0 ){
+  //   Eigen::Quaterniond qua(orientation.w, orientation.x, orientation.y, orientation.z);
+  //   init_state.rot = qua;
+  // }
+
+
   //state_inout.rot = Eye3d; // Exp(mean_acc.cross(V3D(0, 0, -1 / scale_gravity)));
   init_state.bg  = mean_gyr;
   init_state.offset_T_L_I = Lidar_T_wrt_IMU;

--- a/FAST-LIO/src/IMU_Processing.hpp
+++ b/FAST-LIO/src/IMU_Processing.hpp
@@ -195,7 +195,8 @@ void ImuProcess::IMU_init(const MeasureGroup &meas, esekfom::esekf<state_ikfom, 
   const auto& orientation = meas.imu.front()->orientation;
   // 如果orientation消息可用的话,以IMU的orientaion作为初始姿态
   if( orientation.x != 0 || orientation.y != 0 || orientation.z != 0 || orientation.w != 0 ){
-    Eigen::Quaterniond qua(orientation.w, orientation.x, orientation.y, orientation.z);
+    // Eigen::Quaterniond qua(orientation.w, orientation.x, orientation.y, orientation.z);
+    Eigen::Quaterniond qua(1.0 , 0.0, 0.0, 0.0);
     init_state.rot = qua;
   }
   //state_inout.rot = Eye3d; // Exp(mean_acc.cross(V3D(0, 0, -1 / scale_gravity)));

--- a/FAST-LIO/src/laserMapping.cpp
+++ b/FAST-LIO/src/laserMapping.cpp
@@ -158,6 +158,7 @@ geometry_msgs::PoseStamped msg_body_pose, msg_body_pose_updated;
 std::string slam_map_frame = "";
 std::string base_frame = "";
 ros::Publisher pose_publisher;
+ros::Publisher vision_pose_publisher;
 
 shared_ptr<Preprocess> p_pre(new Preprocess());
 shared_ptr<ImuProcess> p_imu(new ImuProcess());
@@ -688,6 +689,7 @@ void publish_path(const ros::Publisher pubPath)
         pubPath.publish(path);
     }
     pose_publisher.publish(msg_body_pose);
+    vision_pose_publisher.publish(msg_body_pose);
 }
 
 void h_share_model(state_ikfom &s, esekfom::dyn_share_datastruct<double> &ekfom_data)
@@ -919,6 +921,7 @@ int main(int argc, char** argv)
     ros::Publisher pubPath_updated          = nh.advertise<nav_msgs::Path>
             ("/path_updated", 100000);
     pose_publisher = nh.advertise<geometry_msgs::PoseStamped>(slam_pose_topic, 10);
+    vision_pose_publisher = nh.advertise<geometry_msgs::PoseStamped>("/mavros/vision_pose/pose", 10);
 //------------------------------------------------------------------------------------------------------
     signal(SIGINT, SigHandle);
     ros::Rate rate(5000);


### PR DESCRIPTION
## Description
When investigating the 90-degree rotation issue in sim, I noticed that it resulted from the fact that /mavros/imu/data has data for 'orientation' while /livox/imu does not (all fields in 'orientation' are 0). So, I commented out the if statement that sets an orientation state to the imu handler when the values are nonzero, and this seems to fix the sim 90-degree rotation issue. 

I also tested these changes on the real drone to make sure it didn't mess up the drone's slam capability, and it did not seem to have an effect. This makes sense as the orientation published by /livox/imu is all 0 anyway, so that if statement should not have been getting hit previously. 

This also adds the publication of "/mavros/vision_pose/pose" to be used as the position estimate for arducopter. 

## Testing
Build and run the code on sim and on the drone, and verify that slam works still. 