### PR TITLE
Bugfix/timestamps

### DIFF
--- a/FAST-LIO/src/laserMapping.cpp
+++ b/FAST-LIO/src/laserMapping.cpp
@@ -158,7 +158,6 @@ geometry_msgs::PoseStamped msg_body_pose, msg_body_pose_updated;
 std::string slam_map_frame = "";
 std::string base_frame = "";
 ros::Publisher pose_publisher;
-// ros::Publisher vision_pose_publisher;
 
 shared_ptr<Preprocess> p_pre(new Preprocess());
 shared_ptr<ImuProcess> p_imu(new ImuProcess());
@@ -532,7 +531,6 @@ void publish_frame_world(const ros::Publisher & pubLaserCloudFull)
 
         sensor_msgs::PointCloud2 laserCloudmsg;
         pcl::toROSMsg(*laserCloudWorld, laserCloudmsg);
-        // laserCloudmsg.header.stamp = ros::Time::now();
         laserCloudmsg.header.stamp = ros::Time().fromSec(lidar_end_time);
         laserCloudmsg.header.frame_id = slam_map_frame;
         pubLaserCloudFull.publish(laserCloudmsg);
@@ -570,7 +568,6 @@ void publish_frame_body(const ros::Publisher & pubLaserCloudFull_body)
 
     sensor_msgs::PointCloud2 laserCloudmsg;
     pcl::toROSMsg(*laserCloudIMUBody, laserCloudmsg);
-    // laserCloudmsg.header.stamp = ros::Time::now();
     laserCloudmsg.header.stamp = ros::Time().fromSec(lidar_end_time);
     laserCloudmsg.header.frame_id = base_frame;
     laserCloudmsg.header.seq = data_seq;
@@ -583,7 +580,6 @@ void publish_frame_lidar(const ros::Publisher & pubLaserCloudFull_lidar)
 {
     sensor_msgs::PointCloud2 laserCloudmsg;
     pcl::toROSMsg(*feats_undistort, laserCloudmsg);
-    // laserCloudmsg.header.stamp = ros::Time::now();
     laserCloudmsg.header.stamp = ros::Time().fromSec(lidar_end_time);
     laserCloudmsg.header.frame_id = "lidar";
     pubLaserCloudFull_lidar.publish(laserCloudmsg);
@@ -601,7 +597,6 @@ void publish_effect_world(const ros::Publisher & pubLaserCloudEffect)
     }
     sensor_msgs::PointCloud2 laserCloudFullRes3;
     pcl::toROSMsg(*laserCloudWorld, laserCloudFullRes3);
-    // laserCloudFullRes3.header.stamp = ros::Time::now();
     laserCloudFullRes3.header.stamp = ros::Time().fromSec(lidar_end_time);
     laserCloudFullRes3.header.frame_id = slam_map_frame;
     pubLaserCloudEffect.publish(laserCloudFullRes3);
@@ -611,7 +606,6 @@ void publish_map(const ros::Publisher & pubLaserCloudMap)
 {
     sensor_msgs::PointCloud2 laserCloudMap;
     pcl::toROSMsg(*featsFromMap, laserCloudMap);
-    // laserCloudMap.header.stamp = ros::Time::now();
     laserCloudMap.header.stamp = ros::Time().fromSec(lidar_end_time);
     laserCloudMap.header.frame_id = slam_map_frame;
     pubLaserCloudMap.publish(laserCloudMap);
@@ -635,7 +629,7 @@ void publish_odometry(const ros::Publisher & pubOdomAftMapped)
     odomAftMapped.header.frame_id = slam_map_frame;
     odomAftMapped.header.seq = data_seq;
     odomAftMapped.child_frame_id = base_frame;
-    odomAftMapped.header.stamp = ros::Time().fromSec(lidar_end_time);// ros::Time().fromSec(lidar_end_time);
+    odomAftMapped.header.stamp = ros::Time().fromSec(lidar_end_time);
     set_posestamp(odomAftMapped.pose);
 
     // odoms[data_seq] = odomAftMapped.pose.pose;  // 保存历史的odom
@@ -676,7 +670,6 @@ void publish_odometry(const ros::Publisher & pubOdomAftMapped)
 void publish_path(const ros::Publisher pubPath)
 {
     set_posestamp(msg_body_pose);
-    // msg_body_pose.header.stamp = ros::Time::now();
     msg_body_pose.header.stamp = ros::Time().fromSec(lidar_end_time);
     msg_body_pose.header.frame_id = slam_map_frame;
 
@@ -689,7 +682,6 @@ void publish_path(const ros::Publisher pubPath)
         pubPath.publish(path);
     }
     pose_publisher.publish(msg_body_pose);
-    // vision_pose_publisher.publish(msg_body_pose);
 }
 
 void h_share_model(state_ikfom &s, esekfom::dyn_share_datastruct<double> &ekfom_data)
@@ -921,7 +913,6 @@ int main(int argc, char** argv)
     ros::Publisher pubPath_updated          = nh.advertise<nav_msgs::Path>
             ("/path_updated", 100000);
     pose_publisher = nh.advertise<geometry_msgs::PoseStamped>(slam_pose_topic, 10);
-    // vision_pose_publisher = nh.advertise<geometry_msgs::PoseStamped>("/mavros/vision_pose/pose", 10);
 //------------------------------------------------------------------------------------------------------
     signal(SIGINT, SigHandle);
     ros::Rate rate(5000);
@@ -1130,7 +1121,6 @@ int main(int argc, char** argv)
                     msg_body_pose_updated.pose.orientation.y = state_updated.rot.y();
                     msg_body_pose_updated.pose.orientation.z = state_updated.rot.z();
                     msg_body_pose_updated.pose.orientation.w = state_updated.rot.w();
-                    // msg_body_pose_updated.header.stamp = ros::Time::now();
                     msg_body_pose_updated.header.stamp = ros::Time().fromSec(lidar_end_time);
                     msg_body_pose_updated.header.frame_id = slam_map_frame;
 

--- a/FAST-LIO/src/laserMapping.cpp
+++ b/FAST-LIO/src/laserMapping.cpp
@@ -158,7 +158,7 @@ geometry_msgs::PoseStamped msg_body_pose, msg_body_pose_updated;
 std::string slam_map_frame = "";
 std::string base_frame = "";
 ros::Publisher pose_publisher;
-ros::Publisher vision_pose_publisher;
+// ros::Publisher vision_pose_publisher;
 
 shared_ptr<Preprocess> p_pre(new Preprocess());
 shared_ptr<ImuProcess> p_imu(new ImuProcess());
@@ -532,8 +532,8 @@ void publish_frame_world(const ros::Publisher & pubLaserCloudFull)
 
         sensor_msgs::PointCloud2 laserCloudmsg;
         pcl::toROSMsg(*laserCloudWorld, laserCloudmsg);
-        laserCloudmsg.header.stamp = ros::Time::now();
-        // laserCloudmsg.header.stamp = ros::Time().fromSec(lidar_end_time);
+        // laserCloudmsg.header.stamp = ros::Time::now();
+        laserCloudmsg.header.stamp = ros::Time().fromSec(lidar_end_time);
         laserCloudmsg.header.frame_id = slam_map_frame;
         pubLaserCloudFull.publish(laserCloudmsg);
         publish_count -= PUBFRAME_PERIOD;
@@ -570,8 +570,8 @@ void publish_frame_body(const ros::Publisher & pubLaserCloudFull_body)
 
     sensor_msgs::PointCloud2 laserCloudmsg;
     pcl::toROSMsg(*laserCloudIMUBody, laserCloudmsg);
-    laserCloudmsg.header.stamp = ros::Time::now();
-    // laserCloudmsg.header.stamp = ros::Time().fromSec(lidar_end_time);
+    // laserCloudmsg.header.stamp = ros::Time::now();
+    laserCloudmsg.header.stamp = ros::Time().fromSec(lidar_end_time);
     laserCloudmsg.header.frame_id = base_frame;
     laserCloudmsg.header.seq = data_seq;
     pubLaserCloudFull_body.publish(laserCloudmsg);
@@ -583,8 +583,8 @@ void publish_frame_lidar(const ros::Publisher & pubLaserCloudFull_lidar)
 {
     sensor_msgs::PointCloud2 laserCloudmsg;
     pcl::toROSMsg(*feats_undistort, laserCloudmsg);
-    laserCloudmsg.header.stamp = ros::Time::now();
-    // laserCloudmsg.header.stamp = ros::Time().fromSec(lidar_end_time);
+    // laserCloudmsg.header.stamp = ros::Time::now();
+    laserCloudmsg.header.stamp = ros::Time().fromSec(lidar_end_time);
     laserCloudmsg.header.frame_id = "lidar";
     pubLaserCloudFull_lidar.publish(laserCloudmsg);
     publish_count -= PUBFRAME_PERIOD;
@@ -601,8 +601,8 @@ void publish_effect_world(const ros::Publisher & pubLaserCloudEffect)
     }
     sensor_msgs::PointCloud2 laserCloudFullRes3;
     pcl::toROSMsg(*laserCloudWorld, laserCloudFullRes3);
-    laserCloudFullRes3.header.stamp = ros::Time::now();
-    // laserCloudFullRes3.header.stamp = ros::Time().fromSec(lidar_end_time);
+    // laserCloudFullRes3.header.stamp = ros::Time::now();
+    laserCloudFullRes3.header.stamp = ros::Time().fromSec(lidar_end_time);
     laserCloudFullRes3.header.frame_id = slam_map_frame;
     pubLaserCloudEffect.publish(laserCloudFullRes3);
 }
@@ -611,8 +611,8 @@ void publish_map(const ros::Publisher & pubLaserCloudMap)
 {
     sensor_msgs::PointCloud2 laserCloudMap;
     pcl::toROSMsg(*featsFromMap, laserCloudMap);
-    laserCloudMap.header.stamp = ros::Time::now();
-    // laserCloudMap.header.stamp = ros::Time().fromSec(lidar_end_time);
+    // laserCloudMap.header.stamp = ros::Time::now();
+    laserCloudMap.header.stamp = ros::Time().fromSec(lidar_end_time);
     laserCloudMap.header.frame_id = slam_map_frame;
     pubLaserCloudMap.publish(laserCloudMap);
 }
@@ -635,7 +635,7 @@ void publish_odometry(const ros::Publisher & pubOdomAftMapped)
     odomAftMapped.header.frame_id = slam_map_frame;
     odomAftMapped.header.seq = data_seq;
     odomAftMapped.child_frame_id = base_frame;
-    odomAftMapped.header.stamp = ros::Time::now();// ros::Time().fromSec(lidar_end_time);// ros::Time().fromSec(lidar_end_time);
+    odomAftMapped.header.stamp = ros::Time().fromSec(lidar_end_time);// ros::Time().fromSec(lidar_end_time);
     set_posestamp(odomAftMapped.pose);
 
     // odoms[data_seq] = odomAftMapped.pose.pose;  // 保存历史的odom
@@ -676,8 +676,8 @@ void publish_odometry(const ros::Publisher & pubOdomAftMapped)
 void publish_path(const ros::Publisher pubPath)
 {
     set_posestamp(msg_body_pose);
-    msg_body_pose.header.stamp = ros::Time::now();
-    // msg_body_pose.header.stamp = ros::Time().fromSec(lidar_end_time);
+    // msg_body_pose.header.stamp = ros::Time::now();
+    msg_body_pose.header.stamp = ros::Time().fromSec(lidar_end_time);
     msg_body_pose.header.frame_id = slam_map_frame;
 
     /*** if path is too large, the rvis will crash ***/
@@ -689,7 +689,7 @@ void publish_path(const ros::Publisher pubPath)
         pubPath.publish(path);
     }
     pose_publisher.publish(msg_body_pose);
-    vision_pose_publisher.publish(msg_body_pose);
+    // vision_pose_publisher.publish(msg_body_pose);
 }
 
 void h_share_model(state_ikfom &s, esekfom::dyn_share_datastruct<double> &ekfom_data)
@@ -921,7 +921,7 @@ int main(int argc, char** argv)
     ros::Publisher pubPath_updated          = nh.advertise<nav_msgs::Path>
             ("/path_updated", 100000);
     pose_publisher = nh.advertise<geometry_msgs::PoseStamped>(slam_pose_topic, 10);
-    vision_pose_publisher = nh.advertise<geometry_msgs::PoseStamped>("/mavros/vision_pose/pose", 10);
+    // vision_pose_publisher = nh.advertise<geometry_msgs::PoseStamped>("/mavros/vision_pose/pose", 10);
 //------------------------------------------------------------------------------------------------------
     signal(SIGINT, SigHandle);
     ros::Rate rate(5000);
@@ -1130,8 +1130,8 @@ int main(int argc, char** argv)
                     msg_body_pose_updated.pose.orientation.y = state_updated.rot.y();
                     msg_body_pose_updated.pose.orientation.z = state_updated.rot.z();
                     msg_body_pose_updated.pose.orientation.w = state_updated.rot.w();
-                    msg_body_pose_updated.header.stamp = ros::Time::now();
-                    // msg_body_pose_updated.header.stamp = ros::Time().fromSec(lidar_end_time);
+                    // msg_body_pose_updated.header.stamp = ros::Time::now();
+                    msg_body_pose_updated.header.stamp = ros::Time().fromSec(lidar_end_time);
                     msg_body_pose_updated.header.frame_id = slam_map_frame;
 
                     /*** if path is too large, the rvis will crash ***/


### PR DESCRIPTION
Reverted timestamp handling to the original (lidar_end_time) for improved performance. Removed vision pose publisher. Should now work better in AirSim (still not great, avoid fast or large rotations). To be tested with the [task manager PR](https://github.com/robotics88official/task-manager/pull/16) fixing compass handling.