### PR TITLE
Airsim lidar processing

### DIFF
--- a/FAST-LIO/config/velodyne_sim.yaml
+++ b/FAST-LIO/config/velodyne_sim.yaml
@@ -4,7 +4,7 @@ common:
     time_sync_en: true         # ONLY turn on when external time synchronization is really not possible
     
 preprocess:
-    lidar_type: 2                # 1 for Livox serials LiDAR, 2 for Velodyne LiDAR, 3 for ouster LiDAR, 
+    lidar_type: 4                # 1 for Livox serials LiDAR, 2 for Velodyne LiDAR, 3 for ouster LiDAR, 4 for Velodyne airsim lidar
     scan_line: 16
     blind: 1                     # blind是min_radius^2
 
@@ -15,7 +15,7 @@ mapping:
     b_gyr_cov: 0.0001
     fov_degree:    180
     det_range:     100.0
-    extrinsic_T: [ 0, 0, -0.1]
+    extrinsic_T: [ 0, 0, 0.1]
     extrinsic_R: [ 1, 0, 0, 
                    0, 1, 0, 
                    0, 0, 1]

--- a/FAST-LIO/launch/mapping_velodyne_sim.launch
+++ b/FAST-LIO/launch/mapping_velodyne_sim.launch
@@ -1,0 +1,47 @@
+<launch>
+  <!-- Launch file for velodyne16 VLP-16 LiDAR -->
+
+    <arg name="imu_topic" default="/mavros/imu/data"/>
+    <arg name="slam_map_frame" default="slam_map"/>
+    <arg name="base_frame" default="base_link"/>
+    <arg name="slam_pose_topic" default="/decco/pose"/>
+
+    <arg name="lc_enable" default="true"/>
+    <arg name="rviz" default="true" />
+
+    <rosparam command="load" file="$(find fast_lio_lc)/config/velodyne_sim.yaml" />
+
+    <!-- 调参说明：  -->
+    <!-- point_filter_num，和filter_size_surf是滤波参数，越小前端效果越好，但运行越慢 -->
+    <param name="feature_extract_enable" type="bool" value="0"/>
+    <param name="point_filter_num" type="int" value="4"/>
+    <param name="max_iteration" type="int" value="3" />
+    <param name="scan_publish_enable" type="bool" value="1" />
+	  <param name="dense_publish_enable" type="bool" value="1" />
+    <param name="filter_size_surf" type="double" value="0.5" />   <!-- 对当前点云的filter -->
+    <param name="filter_size_map" type="double" value="0.2" />    <!-- 对地图的filter -->
+    <param name="cube_side_length" type="double" value="1000" />
+    <param name="debug_mode_enable" type="bool" value="0" />
+    <param name="pcd_save_enable" type="bool" value="0" />
+
+    <!-- visualization -->
+    <param name="visulize_map" value="true"/>
+
+    <!--optimization  -->
+    <param name="recontructKdTree" value="$(arg lc_enable)"/> <!-- 打开更新ikdtree -->
+    <param name="updateState" value="$(arg lc_enable)"/>   <!-- 打开更新状态 -->
+    <param name="updateFrequency" value="30"/> <!-- 每接受updateFrequency个点云，更新一次， 不能太大-->
+    
+    <node pkg="fast_lio_lc" type="fastlio_mapping" name="laserMapping" output="screen" respawn="true">
+      <param name="imu_topic" type="string" value="$(arg imu_topic)"/>
+      <param name="slam_map_frame" type="string" value="$(arg slam_map_frame)"/>
+      <param name="base_frame" type="string" value="$(arg base_frame)"/>
+      <param name="slam_pose_topic" type="string" value="$(arg slam_pose_topic)"/>
+      <param name="frame_id" type="string" value="base_link"/>
+    </node> 
+
+    <group if="$(arg rviz)">
+    <node launch-prefix="nice" pkg="rviz" type="rviz" name="rviz_fast_lio" args="-d $(find fast_lio_lc)/rviz_cfg/loam_livox.rviz" />
+    </group>
+
+</launch>

--- a/FAST-LIO/src/preprocess.h
+++ b/FAST-LIO/src/preprocess.h
@@ -10,7 +10,7 @@ using namespace std;
 typedef pcl::PointXYZINormal PointType;
 typedef pcl::PointCloud<PointType> PointCloudXYZI;
 
-enum LID_TYPE{AVIA = 1, VELO16, OUST64}; //{1, 2, 3}
+enum LID_TYPE{AVIA = 1, VELO16, OUST64, VELO_SIM}; //{1, 2, 3, 4}
 enum Feature{Nor, Poss_Plane, Real_Plane, Edge_Jump, Edge_Plane, Wire, ZeroPoint};
 enum Surround{Prev, Next};
 enum E_jump{Nr_nor, Nr_zero, Nr_180, Nr_inf, Nr_blind};
@@ -104,6 +104,7 @@ class Preprocess
   void avia_handler(const livox_ros_driver::CustomMsg::ConstPtr &msg);
   void oust64_handler(const sensor_msgs::PointCloud2::ConstPtr &msg);
   void velodyne_handler(const sensor_msgs::PointCloud2::ConstPtr &msg);
+  void velodyne_sim_handler(const sensor_msgs::PointCloud2::ConstPtr &msg);
   void give_feature(PointCloudXYZI &pl, vector<orgtype> &types);
   void pub_func(PointCloudXYZI &pl, const ros::Time &ct);
   int  plane_judge(const PointCloudXYZI &pl, vector<orgtype> &types, uint i, uint &i_nex, Eigen::Vector3d &curr_direct);


### PR DESCRIPTION
## Description

Adds a 'velodyne sim handler' to better handle airsim lidar. The main change to the airsim lidar handler compared to the velodyne handler to make the airsim lidar handler work properly is that is does not estimate the timing of the measured points in the pointcloud based on the scanning pattern assumed for the real lidar. This appears to fix sim issues that cause the odometry state estimate to bounce all over the place. 

## Testing

In vehicle-launch, pull the branch from the corresponding pull request: https://github.com/robotics-88/vehicle-launch/pull/25. Build the code and run exploration in sim with slam_type:=1 and verify that exploration completes. Or, at the very least, manually take off the drone via arducopter CLI and verify that the sim drone is stable. 