### PR TITLE
Fixing lidar IMU offset directions

### DIFF
--- a/FAST-LIO/config/mid360.yaml
+++ b/FAST-LIO/config/mid360.yaml
@@ -15,7 +15,7 @@ mapping:
     b_gyr_cov: 0.0001
     fov_degree:    180
     det_range:     260.0
-    extrinsic_T: [ -0.011, -0.02329, -0.04412 ]
+    extrinsic_T: [ -0.011, -0.02329, 0.04412 ] # Lidar center w/r/t IMU
     extrinsic_R: [ 1, 0, 0,
                    0, 1, 0,
                    0, 0, 1]

--- a/FAST-LIO/config/velodyne.yaml
+++ b/FAST-LIO/config/velodyne.yaml
@@ -15,7 +15,7 @@ mapping:
     b_gyr_cov: 0.0001
     fov_degree:    180
     det_range:     100.0
-    extrinsic_T: [ 0, 0, 0.28]
+    extrinsic_T: [ 0, 0, 0.28] # Lidar center w/r/t IMU
     extrinsic_R: [ 1, 0, 0, 
                    0, 1, 0, 
                    0, 0, 1]

--- a/FAST-LIO/config/velodyne16.yaml
+++ b/FAST-LIO/config/velodyne16.yaml
@@ -15,7 +15,7 @@ mapping:
     b_gyr_cov: 0.0001
     fov_degree:    180
     det_range:     100.0
-    extrinsic_T: [ 0, 0, -0.1]
+    extrinsic_T: [ 0, 0, 0.1] # Lidar center w/r/t IMU
     extrinsic_R: [ 1, 0, 0, 
                    0, 1, 0, 
                    0, 0, 1]


### PR DESCRIPTION
## Description

Fixes lidar IMU offsets to be correct direction. The extrinsic_T should reflect the position of the center of the lidar pointcloud [0,0,0] relative to the IMU. 

## Testing

Run the code on the drone and make sure the slam output still appears correct. 