### PR TITLE
bugfix/pointcloud-latency

### DIFF
--- a/FAST-LIO/CMakeLists.txt
+++ b/FAST-LIO/CMakeLists.txt
@@ -51,6 +51,7 @@ find_package(catkin REQUIRED COMPONENTS
   std_msgs
   pcl_ros
   tf
+  tf2_geometry_msgs
   livox_ros_driver
   message_generation
   eigen_conversions

--- a/FAST-LIO/package.xml
+++ b/FAST-LIO/package.xml
@@ -24,6 +24,7 @@
   <build_depend>std_msgs</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>tf</build_depend>
+  <build_depend>tf2_geometry_msgs</build_depend>
   <build_depend>pcl_ros</build_depend>
   <build_depend>livox_ros_driver</build_depend>
   <build_depend>message_generation</build_depend>
@@ -35,6 +36,7 @@
   <run_depend>rospy</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>tf</run_depend>
+  <run_depend>tf2_geometry_msgs</run_depend>
   <run_depend>pcl_ros</run_depend>
   <run_depend>livox_ros_driver</run_depend>
   <run_depend>message_runtime</run_depend>


### PR DESCRIPTION
Changed the pointcloud republishers to use pcl library's transform function rather than looping over the whole pointcloud.

# Test
## Sim
Run in AirSim and confirm the map still looks ok.

## Real world
@gus-robotics88 flight test this change along with that NVIDIA script and see if it fixes the choppy bags. To check your current settings and run the script:
```
sudo jetson_clocks --show
sudo jetson_clocks
sudo jetson_clocks --show
```
I like to check it after to make sure it took effect but you could just run the second line. This resets on boot, but if it works for you we should make it run on startup. Here is an analysis of a bag I recorded in flight with these changes:
![Screenshot from 2024-07-29 10-27-10](https://github.com/user-attachments/assets/57825786-f577-41ad-b08e-6455943f6f36)
